### PR TITLE
Assembly version compatibility

### DIFF
--- a/VSAssemblyResolver/EnumerableExtensions.cs
+++ b/VSAssemblyResolver/EnumerableExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SergejDerjabkin.VSAssemblyResolver
+{
+    /// <summary>
+    /// Extension methods for supporting enumerable collections.
+    /// </summary>
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Selects the maximum element of the given collection based on the given comparison.
+        /// </summary>
+        /// <typeparam name="TElement">The type of the element.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="compare">The comparison method.</param>
+        /// <returns>
+        /// The maximum element found in the collection.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">if the source collection is null.</exception>
+        public static TElement MaxElement<TElement>(this IEnumerable<TElement> source, Comparison<TElement> compare)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+
+            var sourceItems = source.ToArray();
+            if (sourceItems.Length == 0)
+                return default(TElement);
+
+            TElement maxElement = sourceItems[0];
+            foreach (var item in sourceItems.Skip(1))
+            {
+                if (compare(item, maxElement) > 0)
+                    maxElement = item;
+            }
+
+            return maxElement;
+        }
+    }
+}

--- a/VSAssemblyResolver/VSAssemblyResolver.csproj
+++ b/VSAssemblyResolver/VSAssemblyResolver.csproj
@@ -134,6 +134,7 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="Resources.Designer.cs">

--- a/VSAssemblyResolver/VSAssemblyResolverPackage.cs
+++ b/VSAssemblyResolver/VSAssemblyResolverPackage.cs
@@ -334,13 +334,27 @@ namespace SergejDerjabkin.VSAssemblyResolver
         private static bool IsNameCompatible(AssemblyName fullName, AssemblyName partialName)
         {
             return partialName.Name == fullName.Name &&
-                   ((partialName.Version == null) || (partialName.Version == fullName.Version)) &&
-                   ((partialName.GetPublicKeyToken() == null ||
-                    partialName.GetPublicKeyToken().SequenceEqual(fullName.GetPublicKeyToken())));
+                   IsVersionCompatible(fullName.Version, partialName.Version) &&
+                   IsPublicKeyTokenCompatible(fullName.GetPublicKeyToken(), partialName.GetPublicKeyToken());
         }
 
+        /// <summary>
+        /// Determines if the assembly versions are compatible. The found version MUST be greater or equal to the requested version
+        /// and major versions must be the same (different major versions indicate non-backwards-compatible breaking changes).
+        /// </summary>
+        private static bool IsVersionCompatible(Version fullNameVersion, Version partialNameVersion)
+        {
+            return (partialNameVersion == null) ||
+                   (fullNameVersion >= partialNameVersion && fullNameVersion.Major == partialNameVersion.Major);
+        }
 
-
+        /// <summary>
+        /// Determines if the assembly public key tokens are compatible.
+        /// </summary>
+        private static bool IsPublicKeyTokenCompatible(byte[] fullNamePublicKeyToken, byte[] partialNamePublicKeyToken)
+        {
+            return partialNamePublicKeyToken == null || partialNamePublicKeyToken.SequenceEqual(fullNamePublicKeyToken);
+        }
 
         private bool IsMissingAssembly(string name)
         {


### PR DESCRIPTION
Adds support for choosing the closest assembly match using [semantic versioning](http://semver.org/) assuming that a major version bump is most likely incompatible.
